### PR TITLE
Fix composer guzzle version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-curl": "*",
-        "guzzle/guzzle": "3.8.*",
+        "guzzle/guzzle": "~3.7",
         "lstrojny/fxmlrpc": "0.8.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-curl": "*",
-        "guzzle/guzzle": "~3.7",
+        "guzzle/guzzle": "3.8.*",
         "lstrojny/fxmlrpc": "0.8.*"
     },
     "require-dev": {


### PR DESCRIPTION
I would like to integrate your package with a project at work; however we're already working with guzzle/guzzle v3.9.2 due to other vendor dependencies (aws/aws-sdk-php and elasticsearch/elasticsearch) and we cannot downgrade easily. Would you consider relaxing your version requirement for guzzle/guzzle?