### PR TITLE
Fix fatal error running on systems with E_STRICT

### DIFF
--- a/src/Infusionsoft/Http/GuzzleHttpClient.php
+++ b/src/Infusionsoft/Http/GuzzleHttpClient.php
@@ -51,7 +51,7 @@ class GuzzleHttpClient extends Client implements ClientInterface
      * @return mixed
      * @throws HttpException
      */
-    public function request($method, $uri, array $options = [])
+    public function request($method, $uri = NULL, array $options = [])
     {
         if(!isset($options['headers'])){
             $options['headers'] = [];


### PR DESCRIPTION
Fatal error: Declaration of Infusionsoft\Http\GuzzleHttpClient::request() must be compatible with GuzzleHttp\ClientInterface::request($method, $uri = NULL, array $options = Array)