### PR TITLE
Fixing typehint for Invoice date

### DIFF
--- a/src/Infusionsoft/Api/InvoiceService.php
+++ b/src/Infusionsoft/Api/InvoiceService.php
@@ -7,7 +7,7 @@ class InvoiceService extends AbstractApi {
 	/**
 	 * @param integer $contactId
 	 * @param string $description
-	 * @param string $orderDate
+	 * @param \DateTime $orderDate
 	 * @param integer $leadAffiliateId
 	 * @param integer $saleAffiliateId
 	 * @return mixed


### PR DESCRIPTION
After hitting my head on the wall a couple of times, trying to deal with a generic (and leaky) `No method matching arguments: java.lang.String, java.lang.Integer, java.lang.String, java.lang.String, java.lang.Integer, java.lang.Integer`, I discovered the date required to create an Invoice is not a string but actually a DateTime object (hinted to me because the API returns those objects on date fields).

I submitted this patch as a means to warn this might be wrong in other places. I'm unable to check without writing code to test out, so I beg to some contributor to verify and fix type-hints across the SDK as well. I see there's a couple of date fields on this file alone...