### PR TITLE
Added linkContacts method

### DIFF
--- a/src/Infusionsoft/Api/ContactService.php
+++ b/src/Infusionsoft/Api/ContactService.php
@@ -159,7 +159,8 @@ class ContactService extends AbstractApi {
 	 * @param integer $linkId
 	 * @return integer
 	 */
-	public function linkContacts($contactId1, $contactId2, $linkId){
+	public function linkContacts($contactId1, $contactId2, $linkId)
+	{
 	    return $this->client->request("ContactService.linkContacts", $contactId1, $contactId2, $linkId);
 	}
 

--- a/src/Infusionsoft/Api/ContactService.php
+++ b/src/Infusionsoft/Api/ContactService.php
@@ -152,5 +152,15 @@ class ContactService extends AbstractApi {
 	{
 		return $this->client->request('ContactService.update', $contactId, $data);
 	}
+	
+	/**
+	 * @param integer $contactId1
+	 * @param integer $contactId2
+	 * @param integer $linkId
+	 * @return integer
+	 */
+	public function linkContacts($contactId1, $contactId2, $linkId){
+	    return $this->client->request("ContactService.linkContacts", $contactId1, $contactId2, $linkId);
+	}
 
 }


### PR DESCRIPTION
When viewing the Infusionsoft developer docs for linking contacts support, there seems to be no PHP support, while XML-RPC and Python do have support (see https://developer.infusionsoft.com/docs/xml-rpc/#contact-link-contacts). I noticed this while working on a project for a client when attempting to link a child contact with a parent contact. After researching, I found this method that I could add to the ContactService class (see this outdated post: https://community.infusionsoft.com/t/how-can-i-link-contacts-via-the-php-isdk/2935).