### PR TITLE
Honor with() params in RestModel::first()

### DIFF
--- a/src/Infusionsoft/Api/Rest/RestModel.php
+++ b/src/Infusionsoft/Api/Rest/RestModel.php
@@ -261,8 +261,13 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
 
         $this->where('limit', 1);
 
-        if (!empty($this->where)) {
-            $data = $this->client->restfulRequest('get', $this->getIndexUrl(), $this->where);
+        $params = $this->where;
+        if (!empty($this->optionalProperities)) {
+          $params['optional_properties'] = implode(',', $this->optionalProperities);
+        }
+
+        if (!empty($params)) {
+            $data = $this->client->restfulRequest('get', $this->getIndexUrl(), $params);
         } else {
             $data = $this->client->restfulRequest('get', $this->getIndexUrl());
         }

--- a/tests/Infusionsoft/RestModelTest.php
+++ b/tests/Infusionsoft/RestModelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Infusionsoft;
+
+use Infusionsoft\Api\Rest\ContactService;
+use Mockery as m;
+use Psr\Log\NullLogger;
+
+class RestModelTest extends \PHPUnit_Framework_TestCase
+{
+  protected $model;
+
+  protected $client;
+
+  public function setUp()
+  {
+    $this->client = m::mock('Infusionsoft\Infusionsoft');
+    $this->model = new ContactService($this->client);
+  }
+
+  public function testFirst() {
+    $this->mockRestfulRequest([
+      'get',
+      'https://api.infusionsoft.com/crm/rest/v1/contacts',
+      ['limit' => 1],
+    ],
+    [
+      'count' => 1,
+      'contacts' => [['first_name' => 'Bob']],
+    ]);
+
+    $this->assertEquals(
+      'Bob',
+      $this->model->first()->first_name
+    );
+  }
+
+  protected function mockRestfulRequest($args = [], $return = []) {
+    $this->client->shouldReceive('restfulRequest')
+      ->once()
+      ->withArgs($args)
+      ->andReturn($return);
+  }
+}

--- a/tests/Infusionsoft/RestModelTest.php
+++ b/tests/Infusionsoft/RestModelTest.php
@@ -35,6 +35,34 @@ class RestModelTest extends \PHPUnit_Framework_TestCase
     );
   }
 
+  public function testFirstWithClauses() {
+    $this->mockRestfulRequest([
+      'get',
+      'https://api.infusionsoft.com/crm/rest/v1/contacts',
+      [
+        // params should be folded in
+        'limit' => 1,
+        'optional_properties' => 'custom_fields,job_title',
+        'email' => 'bob@example.com',
+      ],
+    ],
+    [
+      'count' => 1,
+      'contacts' => [['first_name' => 'Bob']],
+    ]);
+
+    $bob = $this->model
+      ->where('email', 'bob@example.com')
+      ->with(['custom_fields', 'job_title'])
+      ->first();
+
+    $this->assertEquals(
+      'Bob',
+      $bob->first_name
+    );
+
+  }
+
   protected function mockRestfulRequest($args = [], $return = []) {
     $this->client->shouldReceive('restfulRequest')
       ->once()


### PR DESCRIPTION
I'd like to be able to do something like this:

```php
$bob = $infusionsoft
  ->contacts()
  ->where('email', 'bob@example.com')
  ->with(['custom_fields', 'job_title'])
  ->first();
$fields = $bob->custom_fields; // NULL
```

In this use-case, `RestModel` honors the `where()` but not the `with()` - that is, it finds the right record, but doesn't return it with `custom_fields` or any other optional properties.

This PR updates `first()` to request any `optional_properties` that have been specified.

**NOTES (Edited)**

* Currently I'm using a workaround of calling `where(['optional_properties' => 'custom_fields,...'])` ...but this doesn't seem very expressive to me, and seems to rely a bit too much on internal implementation details. 
* I don't think the `!empty($params)` check (or the `!empty($this->where)` it replaces) is actually necessary, since as far as I can tell it will _always_ be non-empty due to the `where()` call just before, but I kept in there just in case I missed something.