### PR TITLE
Fix session saving in example files.

### DIFF
--- a/samples/addWithDupCheck.php
+++ b/samples/addWithDupCheck.php
@@ -24,6 +24,9 @@ if (isset($_SESSION['token'])) {
 // access token.
 if (isset($_GET['code']) and !$infusionsoft->getToken()) {
     $infusionsoft->requestAccessToken($_GET['code']);
+
+    // Save the serialized token to the current session for subsequent requests
+    $_SESSION['token'] = serialize($infusionsoft->getToken());
 }
 
 function add($infusionsoft, $email)

--- a/samples/taskManager.php
+++ b/samples/taskManager.php
@@ -24,6 +24,9 @@ if (isset($_SESSION['token'])) {
 // access token.
 if (isset($_GET['code']) and !$infusionsoft->getToken()) {
 	$infusionsoft->requestAccessToken($_GET['code']);
+
+    // Save the serialized token to the current session for subsequent requests
+    $_SESSION['token'] = serialize($infusionsoft->getToken());
 }
 
 function taskManager($infusionsoft) {


### PR DESCRIPTION
Add the missing line that saves the token to the session.
It exists in the refresh, but not the initial connection.