### PR TITLE
Contact credit card endpoints

### DIFF
--- a/src/Infusionsoft/Api/Rest/ContactService.php
+++ b/src/Infusionsoft/Api/Rest/ContactService.php
@@ -82,5 +82,22 @@ class ContactService extends RestModel
 
     }
 
+    public function creditCards()
+    {
+        $data = $this->client->restfulRequest('get', $this->getFullUrl($this->id . '/creditCards'));
+        $this->fill($data);
 
+        return $this;
+    }
+
+    public function addCreditCard($cardDetails)
+    {
+        if (!is_array($cardDetails)) {
+            throw new InfusionsoftException('Must be an array of card details');
+        }
+
+        $response = $this->client->restfulRequest('post', $this->getFullUrl($this->id . '/creditCards'), $cardDetails);
+
+        return $response;
+    }
 }


### PR DESCRIPTION
When retrieving a contact I was adding the creditCards method to retrieve their cards. I wanted to know if it would be possible to have the response sent back wrapped in a named index like the tags method does, right now it appends the cards array to the contact object as numerically keyed array items?