### PR TITLE
Update InfusionsoftSerializer.php to increase xml decoding speed if xmlrpc is installed

### DIFF
--- a/src/Infusionsoft/Http/InfusionsoftSerializer.php
+++ b/src/Infusionsoft/Http/InfusionsoftSerializer.php
@@ -4,6 +4,7 @@ namespace Infusionsoft\Http;
 
 use fXmlRpc\Client;
 use fXmlRpc\Exception\ExceptionInterface as fXmlRpcException;
+use fXmlRpc\Parser\BestParserDelegate;
 use fXmlRpc\Parser\NativeParser;
 
 class InfusionsoftSerializer implements SerializerInterface {
@@ -23,8 +24,13 @@ class InfusionsoftSerializer implements SerializerInterface {
 		try
 		{
 			$transport = $client->getXmlRpcTransport();
+			$parser = null;
 
-			$client = new Client($uri, $transport, extension_loaded('xmlrpc') ? new NativeParser() : null);
+			if(extension_loaded('xmlrpc')) {
+			    $parser = new BestParserDelegate();
+			}
+
+			$client = new Client($uri, $transport, $parser);
 
 			$response = $client->call($method, $params);
 

--- a/src/Infusionsoft/Http/InfusionsoftSerializer.php
+++ b/src/Infusionsoft/Http/InfusionsoftSerializer.php
@@ -23,7 +23,7 @@ class InfusionsoftSerializer implements SerializerInterface {
 		{
 			$transport = $client->getXmlRpcTransport();
 
-			$client = new Client($uri, $transport);
+			$client = new Client($uri, $transport, extension_loaded('xmlrpc') ? new NativeParser() : null);
 
 			$response = $client->call($method, $params);
 

--- a/src/Infusionsoft/Http/InfusionsoftSerializer.php
+++ b/src/Infusionsoft/Http/InfusionsoftSerializer.php
@@ -4,6 +4,7 @@ namespace Infusionsoft\Http;
 
 use fXmlRpc\Client;
 use fXmlRpc\Exception\ExceptionInterface as fXmlRpcException;
+use fXmlRpc\Parser\NativeParser;
 
 class InfusionsoftSerializer implements SerializerInterface {
 


### PR DESCRIPTION
Use NativeParser if xmlrpc is loaded (getting 12x faster parsing now)

Fixes #229 by always using the faster parser if the module is installed.

Completely and totally backwards compatible.