### PR TITLE
Testing against 7.3/7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 sudo: false
 
 php:
+  - 7
+  - 7.1
   - 7.2
   - 7.3
   - 7.4
@@ -16,4 +18,5 @@ script: phpunit
 matrix:
   allow_failures:
     - php: 7
+    - php: 7.1
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 7
-  - 7.1
   - 7.2
   - 7.3
   - 7.4


### PR DESCRIPTION
 - Testing against PHP 7.3/7.4
 - Accepting test failures on PHP 7.1 unless support for another php version is added to the travis build