### PR TITLE
REST API: Optional properties

### DIFF
--- a/src/Infusionsoft/Api/Rest/RestModel.php
+++ b/src/Infusionsoft/Api/Rest/RestModel.php
@@ -239,8 +239,14 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
 
     public function get()
     {
+
+        $params = $this->where;
+        if (!empty($this->optionalProperities)) {
+          $params['optional_properties'] = implode(',', $this->optionalProperities);
+        }
+
         if (!empty($this->where)) {
-            $data = $this->client->restfulRequest('get', $this->getIndexUrl(), $this->where);
+            $data = $this->client->restfulRequest('get', $this->getIndexUrl(), $params);
         } else {
             $data = $this->client->restfulRequest('get', $this->getIndexUrl());
         }


### PR DESCRIPTION
This PR fixes a bug where it would not return optional properties if use called `->get()` it only returned option properties on `->first()` and `->find($id)`

Closes #223