### PR TITLE
Fixed REST applying tags for contacts

### DIFF
--- a/src/Infusionsoft/Api/Rest/TagService.php
+++ b/src/Infusionsoft/Api/Rest/TagService.php
@@ -46,20 +46,27 @@ class TagService extends RestModel
         return $response;
     }
 
-    public function addContacts($contactIds)
+    /**
+     * @param array $contactIds
+     * @param int $tagId
+     *
+     * @return mixed
+     * @throws InfusionsoftException
+     */
+    public function addContacts($contactIds, $tagId)
     {
-        if ( ! is_array($contactIds)) {
+        if ( ! is_array($contactIds) ) {
             throw new InfusionsoftException('Must be an array of contact ids');
-        } elseif (count($contactIds) > 100) {
+        }
+        if ( count($contactIds) > 100 ) {
             throw new InfusionsoftException('A maximum of 100 contact ids can be modified at once');
         }
-
+        if ( !is_int($tagId) ) {
+            throw new InfusionsoftException('Tag id must be an integer.');
+        }
         $contacts      = new \stdClass();
         $contacts->ids = $contactIds;
-
-        $response = $this->client->restfulRequest('post', $this->getFullUrl($this->id . '/contacts'), $contacts);
-
-        return $response;
+        return $this->client->restfulRequest('post', $this->getFullUrl($this->id . '/' . $tagId . '/contacts'), $contacts);
     }
 
     public function addCategory($name, $description)


### PR DESCRIPTION
This fixes method that is responsible for this REST path: https://developer.infusionsoft.com/docs/rest/#!/Tags/applyTagToContactIdsUsingPOST

The problem was, method TagService::addContacts() pointed to URI: /tags/contacts but should point to /tags/{tagId}/contacts. TagId param was missing.

Also, i've changed if/elseif behaviour for better readability and adde missing doc, as you do not want to use typed params AFAIK.

