### PR TITLE
Upgraded php-http/guzzle7-adapter to stable release 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "lstrojny/fxmlrpc": "^0.20.0",
         "psr/log": "~1.0",
         "laminas/laminas-diactoros": "^2.0",
-        "php-http/guzzle7-adapter": "^0.1",
+        "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.6"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c16573a862084212e335fc427a2d65d",
+    "content-hash": "759311f07871ee13198969aa7ce87175",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -575,16 +575,16 @@
         },
         {
             "name": "php-http/guzzle7-adapter",
-            "version": "0.1.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/guzzle7-adapter.git",
-                "reference": "1967de656b9679a2a6a66d0e4e16fa99bbed1ad1"
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/guzzle7-adapter/zipball/1967de656b9679a2a6a66d0e4e16fa99bbed1ad1",
-                "reference": "1967de656b9679a2a6a66d0e4e16fa99bbed1ad1",
+                "url": "https://api.github.com/repos/php-http/guzzle7-adapter/zipball/fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
                 "shasum": ""
             },
             "require": {
@@ -629,7 +629,11 @@
                 "Guzzle",
                 "http"
             ],
-            "time": "2020-10-21T17:30:51+00:00"
+            "support": {
+                "issues": "https://github.com/php-http/guzzle7-adapter/issues",
+                "source": "https://github.com/php-http/guzzle7-adapter/tree/1.0.0"
+            },
+            "time": "2021-03-09T07:35:15+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -3229,5 +3233,5 @@
         "php": ">=7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
According to the [release notes for php-http/guzzle7-adapter](https://github.com/php-http/guzzle7-adapter/releases/tag/1.0.0), there are no changes between the locked version 0.1.1 and 1.0.0.

This fixes an installation issue due to other packages requesting the stable version while Infusionsoft requires ^0.1
Tests continue to run fine since there are no changes between guzzle7-adapter 0.1.1 and 1.0.0