### PR TITLE
Add two new REST services, Affiliate and Locale

### DIFF
--- a/src/Infusionsoft/Api/Rest/AffiliateService.php
+++ b/src/Infusionsoft/Api/Rest/AffiliateService.php
@@ -1,0 +1,86 @@
+<?php namespace Infusionsoft\Api\Rest;
+
+use Infusionsoft\Api\Rest\Traits\CannotDelete;
+use Infusionsoft\Api\Rest\Traits\CannotSave;
+use Infusionsoft\Api\Rest\Traits\CannotSync;
+use Infusionsoft\Infusionsoft;
+
+class AffiliateService extends RestModel
+{
+    use CannotSync, CannotSave, CannotDelete;
+
+    public $full_url = 'https://api.infusionsoft.com/crm/rest/v1/affiliates';
+
+    public $return_key = 'affiliates';
+
+    public function __construct(Infusionsoft $client)
+    {
+        parent::__construct($client);
+    }
+
+    /**
+     * Retrieves a list of all affiliate clawbacks
+     *
+     * @param array $params
+     * @return array
+     */
+    public function clawbacks($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl($this->id . '/clawbacks'), $params);
+    }
+
+    /**
+     * Retrieves a list of all affiliate payments
+     *
+     * @param array $params
+     * @return array
+     */
+    public function payments($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl($this->id . '/payments'), $params);
+    }
+
+    /**
+     * Retrieve a list of Commissions based on Affiliate or Date Range
+     *
+     * @param array $params
+     * @return array
+     */
+    public function commissions($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/commissions'), $params);
+    }
+
+    /**
+     * Retrieve a list of Commission Programs
+     *
+     * @param array $params
+     * @return array
+     */
+    public function programs($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/programs'), $params);
+    }
+
+    /**
+     * Retrieves a list of all affiliate redirects
+     *
+     * @param array $params
+     * @return array
+     */
+    public function redirectLinks($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/redirectlinks'), $params);
+    }
+
+    /**
+     * Retrieve a list of affiliate summaries
+     *
+     * @param array $params
+     * @return array
+     */
+    public function summaries($params = [])
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/summaries'), $params);
+    }
+}

--- a/src/Infusionsoft/Api/Rest/LocaleService.php
+++ b/src/Infusionsoft/Api/Rest/LocaleService.php
@@ -1,0 +1,48 @@
+<?php namespace Infusionsoft\Api\Rest;
+
+use Infusionsoft\Api\Rest\Traits\CannotCreate;
+use Infusionsoft\Api\Rest\Traits\CannotDelete;
+use Infusionsoft\Api\Rest\Traits\CannotFind;
+use Infusionsoft\Api\Rest\Traits\CannotList;
+use Infusionsoft\Api\Rest\Traits\CannotModel;
+use Infusionsoft\Api\Rest\Traits\CannotSave;
+use Infusionsoft\Api\Rest\Traits\CannotSync;
+use Infusionsoft\Api\Rest\Traits\CannotWhere;
+use Infusionsoft\Infusionsoft;
+
+class LocaleService extends RestModel
+{
+    use CannotSync, CannotSave, CannotDelete, CannotFind;
+    use CannotList, CannotModel, CannotWhere, CannotDelete, CannotCreate;
+
+    public $full_url = 'https://api.infusionsoft.com/crm/rest/v1/locales';
+
+    public $return_key = 'locales';
+
+    public function __construct(Infusionsoft $client)
+    {
+        parent::__construct($client);
+    }
+
+    /**
+     * Retrieves a list of all countries
+     *
+     * @param array $params
+     * @return array
+     */
+    public function countries()
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/countries'));
+    }
+
+    /**
+     * Retrieves a list of all provinces for given country
+     *
+     * @param array $params
+     * @return array
+     */
+    public function provinces($country_code = '')
+    {
+        return $this->client->restfulRequest('get', $this->getFullUrl('/countries/' . $country_code . '/provinces'));
+    }
+}

--- a/src/Infusionsoft/Infusionsoft.php
+++ b/src/Infusionsoft/Infusionsoft.php
@@ -568,9 +568,13 @@ class Infusionsoft
     /**
      * @return \Infusionsoft\Api\AffiliateService
      */
-    public function affiliates()
+    public function affiliates($api = 'rest')
     {
-        return $this->getApi('AffiliateService');
+        if ($api == 'xml') {
+            return $this->getApi('AffiliateService');
+        }
+
+        return $this->getRestApi('AffiliateService');
     }
 
     /**
@@ -653,6 +657,14 @@ class Infusionsoft
     public function invoices()
     {
         return $this->getApi('InvoiceService');
+    }
+
+    /**
+     * @return \Infusionsoft\Api\Rest\LocaleService
+     */
+    public function locales()
+    {
+        return $this->getRestApi('LocaleService');
     }
 
     /**
@@ -854,4 +866,3 @@ class Infusionsoft
     }
 
 }
-


### PR DESCRIPTION
Add two new REST services , Affiliate and Locale. Take note that the affiliate service addition could and probably will be a breaking change due to REST being the first option whereas XML was the only option previously.

Ive tested each service and their methods using our Infusionsoft API credentials.