### PR TITLE
Guzzle Exception Changes

### DIFF
--- a/src/Infusionsoft/Http/GuzzleHttpClient.php
+++ b/src/Infusionsoft/Http/GuzzleHttpClient.php
@@ -4,7 +4,7 @@ namespace Infusionsoft\Http;
 
 use fXmlRpc\Transport\HttpAdapterTransport;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TransferException; 
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7\Request;
@@ -70,7 +70,7 @@ class GuzzleHttpClient extends Client implements ClientInterface
             $response = $this->send($request);
 
             return $response->getBody();
-        } catch (BadResponseException $e) {
+        } catch (TransferException $e) {
             throw new HttpException($e->getMessage(), $e->getCode(), $e);
         }
     }


### PR DESCRIPTION
Newer versions of Guzzle will throw a `BadResponseException` if there is an issue with the server response. They also now throw a `ConnectException` if there are troubles connecting (timeout, curl, etc). 

If you are targeting PHP 7.1+, you could use a union catch `catch (BadResponseException | ConnectException $e)` but if the target is just PHP 7, then you can use the `TransferException` as both `BadResponseException` and `ConnectException` extend it.