### PR TITLE
fix deprecation warnings with attribute #[\ReturnTypeWillChange]

### DIFF
--- a/src/Infusionsoft/Api/Rest/RestModel.php
+++ b/src/Infusionsoft/Api/Rest/RestModel.php
@@ -571,6 +571,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
@@ -982,6 +983,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->$offset);
@@ -994,6 +996,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->$offset;
@@ -1007,6 +1010,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->$offset = $value;
@@ -1019,6 +1023,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->$offset);

--- a/src/Infusionsoft/InfusionsoftCollection.php
+++ b/src/Infusionsoft/InfusionsoftCollection.php
@@ -112,6 +112,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 *
 	 * @return array
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
 		return $this->toArray();
@@ -133,6 +134,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 *
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return count($this->items);
@@ -144,6 +146,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $key
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($key)
 	{
 		return array_key_exists($key, $this->items);
@@ -155,6 +158,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $key
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($key)
 	{
 		return $this->items[$key];
@@ -167,6 +171,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $value
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($key, $value)
 	{
 		if (is_null($key)) {
@@ -182,6 +187,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  string  $key
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($key)
 	{
 		unset($this->items[$key]);


### PR DESCRIPTION
Fixes deprecation warnings in PHP 8.1:

```shell
PHP Deprecated:  Return type of Infusionsoft\Api\Rest\RestModel::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/Api/Rest/RestModel.php on line 985
PHP Deprecated:  Return type of Infusionsoft\Api\Rest\RestModel::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/Api/Rest/RestModel.php on line 997
PHP Deprecated:  Return type of Infusionsoft\Api\Rest\RestModel::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/Api/Rest/RestModel.php on line 1010
PHP Deprecated:  Return type of Infusionsoft\Api\Rest\RestModel::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/Api/Rest/RestModel.php on line 1022
PHP Deprecated:  Return type of Infusionsoft\Api\Rest\RestModel::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/Api/Rest/RestModel.php on line 574
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 147
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 158
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 170
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 185
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 136
PHP Deprecated:  Return type of Infusionsoft\InfusionsoftCollection::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in infusionsoft-php/src/Infusionsoft/InfusionsoftCollection.php on line 115
```

