### PR TITLE
Fix broken restful call params override

### DIFF
--- a/src/Infusionsoft/Infusionsoft.php
+++ b/src/Infusionsoft/Infusionsoft.php
@@ -511,16 +511,14 @@ class Infusionsoft
     {
         // Before making the request, we can make sure that the token is still
         // valid by doing a check on the end of life.
-        $token = $this->getToken();
         if ($this->authenticationType === AuthenticationType::OAuth2AccessToken && $this->isTokenExpired()) {
             throw new TokenExpiredException;
         }
 
-        $client      = $this->getHttpClient();
-        $params = [];
+        $client = $this->getHttpClient();
 
         if (strtolower($method) === 'get' || strtolower($method) === 'delete') {
-            $url    = $url . '?' . http_build_query($params);
+            $url = $url . '?' . http_build_query($params);
         } else {
             $params['body'] = json_encode($params);
         }


### PR DESCRIPTION
Called out by [[mfadul24](https://github.com/mfadul24) in [https://github.com/infusionsoft/infusionsoft-php/pull/321](#321) , reducing the complexity here by dropping a redundant map but left an array instantiation in place accidentally.