### PR TITLE
Add missing class import for Exception

### DIFF
--- a/src/Infusionsoft/Infusionsoft.php
+++ b/src/Infusionsoft/Infusionsoft.php
@@ -2,6 +2,7 @@
 
 namespace Infusionsoft;
 
+use Exception;
 use Infusionsoft\AuthenticationType;
 use Infusionsoft\Http\ArrayLogger;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
Fixes #328

This PR imports the `Exception` class in `\Infusionsoft\Infusionsoft`, which is currently missing.