### PR TITLE
Issue #287 - Always use fallback XML parser to avoid reported failure

### DIFF
--- a/src/Infusionsoft/Http/InfusionsoftSerializer.php
+++ b/src/Infusionsoft/Http/InfusionsoftSerializer.php
@@ -4,8 +4,7 @@ namespace Infusionsoft\Http;
 
 use fXmlRpc\Client;
 use fXmlRpc\Exception\ExceptionInterface as fXmlRpcException;
-use fXmlRpc\Parser\BestParserDelegate;
-use fXmlRpc\Parser\NativeParser;
+use fXmlRpc\Parser\XmlReaderParser;
 
 class InfusionsoftSerializer implements SerializerInterface {
 
@@ -24,11 +23,8 @@ class InfusionsoftSerializer implements SerializerInterface {
 		try
 		{
 			$transport = $client->getXmlRpcTransport();
-			$parser = null;
 
-			if(extension_loaded('xmlrpc')) {
-			    $parser = new BestParserDelegate();
-			}
+            $parser = new XmlReaderParser(true);
 
 			$client = new Client($uri, $transport, $parser);
 


### PR DESCRIPTION
Per Issue #287, always use the library XML parser rather than trying to use the native (which is only used in payloads under 10mb regardless)