### PR TITLE
Add missing parameter & return types

### DIFF
--- a/src/Infusionsoft/Api/Rest/RestModel.php
+++ b/src/Infusionsoft/Api/Rest/RestModel.php
@@ -571,7 +571,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }
@@ -982,7 +982,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->$offset);
     }
@@ -994,7 +994,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->$offset;
     }
@@ -1007,7 +1007,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->$offset = $value;
     }
@@ -1019,7 +1019,7 @@ abstract class RestModel implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->$offset);
     }

--- a/src/Infusionsoft/InfusionsoftCollection.php
+++ b/src/Infusionsoft/InfusionsoftCollection.php
@@ -112,7 +112,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 *
 	 * @return array
 	 */
-	public function jsonSerialize()
+	public function jsonSerialize(): mixed
 	{
 		return $this->toArray();
 	}
@@ -133,7 +133,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 *
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		return count($this->items);
 	}
@@ -144,7 +144,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $key
 	 * @return bool
 	 */
-	public function offsetExists($key)
+	public function offsetExists(mixed $key): bool
 	{
 		return array_key_exists($key, $this->items);
 	}
@@ -155,7 +155,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $key
 	 * @return mixed
 	 */
-	public function offsetGet($key)
+	public function offsetGet(mixed $key): mixed
 	{
 		return $this->items[$key];
 	}
@@ -167,7 +167,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  mixed  $value
 	 * @return void
 	 */
-	public function offsetSet($key, $value)
+	public function offsetSet(mixed $key, mixed $value): void
 	{
 		if (is_null($key)) {
 			$this->items[] = $value;
@@ -182,7 +182,7 @@ class InfusionsoftCollection implements ArrayAccess, Countable, JsonSerializable
 	 * @param  string  $key
 	 * @return void
 	 */
-	public function offsetUnset($key)
+	public function offsetUnset(mixed $key): void
 	{
 		unset($this->items[$key]);
 	}


### PR DESCRIPTION
Gets rid of all the `PHP Deprecated:  Return type ... should either be compatible with ...` messages in error log