### PR TITLE
Declare $client to avoid deprecation notice

### DIFF
--- a/src/Infusionsoft/Api/AbstractApi.php
+++ b/src/Infusionsoft/Api/AbstractApi.php
@@ -6,9 +6,8 @@ use Infusionsoft\Infusionsoft;
 
 abstract class AbstractApi {
 
-	public function __construct(Infusionsoft $client)
-	{
-		$this->client = $client;
-	}
+	public function __construct(
+		public Infusionsoft $client
+	){ }
 
 }


### PR DESCRIPTION
In PHP 8.2 and later, setting a value on an undeclared class prop emits a deprecation notice.