### PR TITLE
Use strict comparison operator to check authentication type

### DIFF
--- a/src/Infusionsoft/Infusionsoft.php
+++ b/src/Infusionsoft/Infusionsoft.php
@@ -110,7 +110,7 @@ class Infusionsoft
         } else if (isset($config['apikey'])) {
             $this->apikey = $config['apikey'];
 
-            if ( substr_compare($this->apikey, 'KeapAK', 0, strlen('KeapAK') ) ) {
+            if ( substr_compare($this->apikey, 'KeapAK', 0, strlen('KeapAK') ) === 0) {
                 $this->authenticationType = AuthenticationType::ServiceAccountKey;
             } else {
                 $this->authenticationType = AuthenticationType::LegacyKey;


### PR DESCRIPTION
- Changed the `substr_compare` condition to explicitly check for equality (=== 0) when verifying the apikey prefix as `'KeapAK'`.

- This ensures correct authentication type assignment for matching API keys.